### PR TITLE
Reload sshd after changing its configuration

### DIFF
--- a/scripts/enable-password-auth/configure
+++ b/scripts/enable-password-auth/configure
@@ -22,3 +22,4 @@
 #==============================================================================
 sed -i -e 's/^PasswordAuthentication no/PasswordAuthentication yes/g' \
     /etc/ssh/sshd_config
+systemctl reload sshd


### PR DESCRIPTION
In my tests I couldn't ssh in with a password until I'd ssh'd in with an ssh key and ran `sudo systemctl reload sshd`.