### PR TITLE
Report launch queue management support when queue-personality feature is installed

### DIFF
--- a/features/index.yml
+++ b/features/index.yml
@@ -317,8 +317,10 @@ profiles:
     - hidden
   queue-personality:
     manifest:
+    - configure.d/add-www-attributes
     - event-periodic.d/queue-manager.sh
     - node-started.d/queue-creator.sh
+    - resources/alces-flight-www/queue-management/attributes.json.tpl
     - share/queue-manager.rb
     tags:
     - config

--- a/features/queue-personality/configure.d/add-www-attributes
+++ b/features/queue-personality/configure.d/add-www-attributes
@@ -1,0 +1,1 @@
+../../../scripts/queues/configure

--- a/features/queue-personality/manifest.txt
+++ b/features/queue-personality/manifest.txt
@@ -1,3 +1,5 @@
+configure.d/add-www-attributes
 event-periodic.d/queue-manager.sh
 node-started.d/queue-creator.sh
+resources/alces-flight-www/queue-management/attributes.json.tpl
 share/queue-manager.rb

--- a/features/queue-personality/resources
+++ b/features/queue-personality/resources
@@ -1,0 +1,1 @@
+../../scripts/queues/resources

--- a/scripts/queues/configure
+++ b/scripts/queues/configure
@@ -1,0 +1,51 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2017 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Clusterware.
+#
+# Alces Clusterware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Clusterware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on the Alces Clusterware, please visit:
+# https://github.com/alces-software/clusterware
+#==============================================================================
+setup() {
+    local a xdg_config
+    IFS=: read -a xdg_config <<< "${XDG_CONFIG_HOME:-$HOME/.config}:${XDG_CONFIG_DIRS:-/etc/xdg}"
+    for a in "${xdg_config[@]}"; do
+        if [ -e "${a}"/clusterware/config.rc ]; then
+            source "${a}"/clusterware/config.rc
+            break
+        fi
+    done
+    if [ -z "${cw_ROOT}" ]; then
+        echo "$0: unable to locate clusterware configuration"
+        exit 1
+    fi
+    kernel_load
+}
+
+main() {
+    if handler_is_enabled cluster-www; then
+        "${cw_ROOT}"/libexec/share/www-add-attributes \
+                    "${_RESOURCES_DIR}"/alces-flight-www/queue-management/attributes.json.tpl
+    fi
+}
+
+setup
+require handler
+
+_RESOURCES_DIR="$(handler_dir)/../resources"
+
+main "$@"

--- a/scripts/queues/resources/alces-flight-www/queue-management/attributes.json.tpl
+++ b/scripts/queues/resources/alces-flight-www/queue-management/attributes.json.tpl
@@ -1,0 +1,3 @@
+{
+  "hasQueueManangement": true
+}


### PR DESCRIPTION
This PR adds a configure script to the `queue-personality` feature which adds the `hasQueueManagement: true` flag to the JSON document used by Flight Launch for the cluster access tab.

@mjtko yesterday we discussed having this flag installed by the `clusterware-compute` service. That would have had some issues with the beegfs cluster reporting that it supports queue management.  I've taken a different route than I thought I would.  With a number of advantages:

 - Installing the `clusterware-compute` service isn't sufficient to support Flight Launch based queue management.  The `queue-personality` profile needs installing too.

 - The beegfs cluster spec doesn't include the `queue-personality` profile, so we more cleanly avoid the issue of not wanting queue support for that cluster.

 - We can easily launch clusters with the `queue-personality` profile when we want to demo Flight Launch based queue management.

Are you happy for this to be merged and synced as `2017.2-dev`?  Or is there some reason why this method is a bad idea?
