### PR TITLE
Better configuration for queue manager endpoint

### DIFF
--- a/scripts/enable-web-terminal/configure
+++ b/scripts/enable-web-terminal/configure
@@ -43,8 +43,8 @@ main() {
         return 0
     fi
 
-    "${cw_ROOT}"/bin/alces service install alces-web-terminal
-    "${cw_ROOT}"/bin/alces service enable alces-web-terminal
+    "${cw_ROOT}"/bin/alces service install flight/alces-web-terminal
+    "${cw_ROOT}"/bin/alces service enable flight/alces-web-terminal/base
 }
 
 setup

--- a/scripts/enginframe/2015.1/configure
+++ b/scripts/enginframe/2015.1/configure
@@ -170,7 +170,7 @@ _execute_installer() {
 _setup_flight_www() {
     if serviceware_is_installed alces-flight-www; then
         cp -R ${_RESOURCES_DIR}/alces-flight-www/etc/* "${cw_ROOT}/etc/alces-flight-www"
-        if handler_is_enabled cluster-www; then
+        if handler_is_enabled flight-www; then
             "${cw_ROOT}"/libexec/share/www-add-attributes ${_RESOURCES_DIR}/alces-flight-www/enginframe/attributes.json.tpl
         fi
     fi

--- a/scripts/enginframe/2017.0/configure
+++ b/scripts/enginframe/2017.0/configure
@@ -170,7 +170,7 @@ _execute_installer() {
 _setup_flight_www() {
     if serviceware_is_installed alces-flight-www; then
         cp -R ${_RESOURCES_DIR}/alces-flight-www/etc/* "${cw_ROOT}/etc/alces-flight-www"
-        if handler_is_enabled cluster-www; then
+        if handler_is_enabled flight-www; then
             "${cw_ROOT}"/libexec/share/www-add-attributes ${_RESOURCES_DIR}/alces-flight-www/enginframe/attributes.json.tpl
         fi
     fi

--- a/scripts/queues/configure
+++ b/scripts/queues/configure
@@ -37,7 +37,7 @@ setup() {
 }
 
 main() {
-    if handler_is_enabled cluster-www; then
+    if handler_is_enabled flight-www; then
         "${cw_ROOT}"/libexec/share/www-add-attributes \
                     "${_RESOURCES_DIR}"/alces-flight-www/queue-management/attributes.json.tpl
     fi

--- a/scripts/queues/queue-manager.sh
+++ b/scripts/queues/queue-manager.sh
@@ -36,6 +36,30 @@ setup() {
     kernel_load
 }
 
+_queues_load_personality() {
+  if [ -z "${_QUEUES_PERSONALITY_LOADED}" ]; then
+    eval $(_queues_extract_personality)
+    _QUEUES_PERSONALITY_LOADED=true
+  fi
+}
+
+_queues_extract_personality() {
+  ruby_run <<RUBY
+require 'yaml'
+p_file = '${cw_ROOT}/etc/personality.yml'
+begin
+  if File.exists?(p_file)
+    personality = YAML.load_file(p_file)
+    if queues_config = personality['queue-manager']
+      queues_config.each do |key, value|
+        puts "_QUEUES_#{key}=#{value}"
+      end
+    end
+  end
+end
+RUBY
+}
+
 _queues_cluster_uuid() {
   if [ -z "${cw_CLUSTER_uuid}" ]; then
       files_load_config config config/cluster
@@ -46,10 +70,11 @@ _queues_cluster_uuid() {
 _queues_endpoint() {
   local uuid
   uuid="$(_queues_cluster_uuid)"
-  echo "${_QUEUES_ENDPOINT_URL:-https://launch.alces-flight.com}/api/v1/clusters/${uuid}/compute-queue-actions"
+  echo "${_QUEUES_endpoint_url:-https://launch.alces-flight.com}/api/v1/clusters/${uuid}/compute-queue-actions"
 }
 
 main() {
+  _queues_load_personality
   local feature_dir
   files_load_config instance config/cluster
   if [ "${cw_INSTANCE_role}" != "master" ]; then


### PR DESCRIPTION
This PR adds support for configuring the API endpoint used by the queue manager, via the `personality.yml` file.  This enables a Flight Launch installation to ensure that it is used for managing the queues of the clusters that it launches.
